### PR TITLE
Upgrade mime package to 2.5.2 and remove audio/amr customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "jimp": "^0.16.1",
     "jsqr": "^1.3.1",
-    "mime": "^2.5.0",
+    "mime": "^2.5.2",
     "qrcode": "^1.4.4"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-box",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "description": "Pack a File into Box for easy move/transfer between servers no matter of where it is.(local path, remote url, or cloud storage)",
   "main": "dist/src/mod.js",
   "typings": "dist/src/mod.d.ts",

--- a/src/file-box.ts
+++ b/src/file-box.ts
@@ -11,12 +11,12 @@ import http      from 'http'
 import nodePath  from 'path'
 import nodeUrl   from 'url'
 
+import mime  from 'mime'
+
 import {
   PassThrough,
   Readable,
 }                     from 'stream'
-
-import { mime }            from './mime-ext'
 
 import {
   VERSION,

--- a/src/mime-ext.ts
+++ b/src/mime-ext.ts
@@ -1,9 +1,0 @@
-import mime from 'mime'
-
-mime.define({
-  'audio/amr': [
-    'amr',
-  ],
-})
-
-export { mime }


### PR DESCRIPTION
Closes #52 

broofa/mime#253 adds support for `audio/amr` and is released in 2.5.2. 