### PR TITLE
optional md5 property

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,21 +73,21 @@ fileBox3.toDataURL()
 
 ### 1. Load File in to Box
 
-#### 1.1 optional argumetns: 
+#### 1.1 `fromFile(filePath: string, name?: string, md5?: string): FileBox`
+
+Alias: `fromLocal()`
+
+About optional arguments:
 
 name: filename, if not passed, will be parsed from file path, url, etc.
 
 md5: file md5 code, only for checking purposes and will not be computed from file.
 
-#### 1.2 `fromFile(filePath: string, name?: string, md5?: string): FileBox`
-
-Alias: `fromLocal()`
-
 ```ts
 const fileBox = FileBox.fromLocal('/tmp/test.txt')
 ```
 
-#### 1.3 `fromUrl(url: string, options?: {headers?: HTTP.OutgoingHttpHeaders, name?: string, size?: string, md5?: string}): FileBox` 
+#### 1.2 `fromUrl(url: string, options?: {headers?: HTTP.OutgoingHttpHeaders, name?: string, size?: string, md5?: string}): FileBox` 
 
 
 Alias: `fromRemote()`
@@ -99,7 +99,7 @@ const fileBox = FileBox.fromUrl(
 )
 ```
 
-#### 1.4 `fromStream(stream: Readable, name?: string, md5?: string): FileBox`
+#### 1.3 `fromStream(stream: Readable, name?: string, md5?: string): FileBox`
 
 Will be named 'stream.dat' if no name is provided.
 
@@ -107,7 +107,7 @@ Will be named 'stream.dat' if no name is provided.
 const fileBox = FileBox.fromStream(res, '/tmp/download.zip')
 ```
 
-#### 1.5 `fromBuffer(buffer: Buffer, name?: string, md5?: string): FileBox`
+#### 1.4 `fromBuffer(buffer: Buffer, name?: string, md5?: string): FileBox`
 
 Will be named 'buffer.dat' if no name is provided.
 
@@ -115,7 +115,7 @@ Will be named 'buffer.dat' if no name is provided.
 const fileBox = FileBox.fromBuffer(buf, '/tmp/download.zip')
 ```
 
-#### 1.6 `FileBox.fromBase64(base64: string, name?: string, md5?: string): FileBox`
+#### 1.5 `FileBox.fromBase64(base64: string, name?: string, md5?: string): FileBox`
 
 Decoded a base64 encoded file data. Will be named 'base64.dat' if no name is provided.
 
@@ -125,7 +125,7 @@ const fileBox = FileBox.fromBase64('d29ybGQK', 'hello.txt')
 fileBox.toFile()
 ```
 
-#### 1.7 `FileBox.fromDataURL(dataUrl: string, name?: string, md5?: string): FileBox`
+#### 1.6 `FileBox.fromDataURL(dataUrl: string, name?: string, md5?: string): FileBox`
 
 Decoded a DataURL data. Will be named 'data-url.dat' if no name is provided.
 
@@ -134,7 +134,7 @@ const fileBox = FileBox.fromDataURL('data:text/plain;base64,d29ybGQK', 'hello.tx
 fileBox.toFile()
 ```
 
-#### 1.8 `FileBox.fromJSON()`
+#### 1.7 `FileBox.fromJSON()`
 
 Restore a `FileBox.toJSON()` text string back to a FileBox instance.
 
@@ -142,7 +142,7 @@ Restore a `FileBox.toJSON()` text string back to a FileBox instance.
 const restoredFileBox = FileBox.fromJSON(jsonText)
 ```
 
-#### 1.9 `FileBox.fromQRCode(qrCodeValue: string, md5?: string)`
+#### 1.8 `FileBox.fromQRCode(qrCodeValue: string, md5?: string)`
 
 Get a FileBox instance that represent a QR Code value.
 
@@ -151,7 +151,7 @@ const fileBox = FileBox.fromQRCode('https://github.com')
 fileBox.toFile('qrcode.png')
 ```
 
-#### 1.10 `FileBox.fromUuid(uuid: string, options?: {name?: string, size?: string, md5?: string})`
+#### 1.9 `FileBox.fromUuid(uuid: string, options?: {name?: string, size?: string, md5?: string})`
 
 Load a FileBox from a UUID. Will be named `${uuid}.dat` if no name is provided.
 
@@ -313,9 +313,9 @@ File md5 of the file in the box. The value is set by user, not computed from fil
 ```ts
 const fileBox = FileBox.fromUrl(
   'https://huan.github.io/file-box/images/file-box-logo.jpg',
-  {md5: 'some-random-md5'}
+  {md5: 'computed-md5-string'}
 )
-console.log(fileBox.md5) // Output: some-random-md5
+console.log(fileBox.md5) // Output: computed-md5-string
 ```
 
 #### 3.3 `metadata: Metadata { [key: string]: any }`

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ fileBox3.toDataURL()
 
 ### 1. Load File in to Box
 
-#### 1.1 `fromFile(filePath: string): FileBox`
+#### 1.1 optional argumetns: 
+
+name: filename, if not passed, will be parsed from file path, url, etc.
+
+md5: file md5 code, only for checking purposes and will not be computed from file.
+
+#### 1.2 `fromFile(filePath: string, name?: string, md5?: string): FileBox`
 
 Alias: `fromLocal()`
 
@@ -81,48 +87,54 @@ Alias: `fromLocal()`
 const fileBox = FileBox.fromLocal('/tmp/test.txt')
 ```
 
-#### 1.2 `fromUrl(url: string, name?: string, headers?: http.OutgoingHttpHeaders): FileBox`
+#### 1.3 `fromUrl(url: string, options?: {headers?: HTTP.OutgoingHttpHeaders, name?: string, size?: string, md5?: string}): FileBox` 
+
 
 Alias: `fromRemote()`
 
 ```ts
 const fileBox = FileBox.fromUrl(
   'https://huan.github.io/file-box/images/file-box-logo.jpg',
-  'logo.jpg',
+  {name: 'logo.jpg'},
 )
 ```
 
-#### 1.3 `fromStream(stream: Readable, name: string): FileBox`
+#### 1.4 `fromStream(stream: Readable, name?: string, md5?: string): FileBox`
+
+Will be named 'stream.dat' if no name is provided.
 
 ```ts
 const fileBox = FileBox.fromStream(res, '/tmp/download.zip')
 ```
 
-#### 1.4 `fromBuffer(buffer: Buffer, name: string): FileBox`
+#### 1.5 `fromBuffer(buffer: Buffer, name?: string, md5?: string): FileBox`
+
+Will be named 'buffer.dat' if no name is provided.
 
 ```ts
 const fileBox = FileBox.fromBuffer(buf, '/tmp/download.zip')
 ```
 
-#### 1.5 `FileBox.fromBase64(base64: string, name: string): FileBox`
+#### 1.6 `FileBox.fromBase64(base64: string, name?: string, md5?: string): FileBox`
 
-Decoded a base64 encoded file data.
+Decoded a base64 encoded file data. Will be named 'base64.dat' if no name is provided.
+
 
 ```ts
 const fileBox = FileBox.fromBase64('d29ybGQK', 'hello.txt')
 fileBox.toFile()
 ```
 
-#### 1.6 `FileBox.fromDataURL(dataUrl: string, name: string): FileBox`
+#### 1.7 `FileBox.fromDataURL(dataUrl: string, name?: string, md5?: string): FileBox`
 
-Decoded a DataURL data.
+Decoded a DataURL data. Will be named 'data-url.dat' if no name is provided.
 
 ```ts
 const fileBox = FileBox.fromDataURL('data:text/plain;base64,d29ybGQK', 'hello.txt')
 fileBox.toFile()
 ```
 
-#### 1.7 `FileBox.fromJSON()`
+#### 1.8 `FileBox.fromJSON()`
 
 Restore a `FileBox.toJSON()` text string back to a FileBox instance.
 
@@ -130,7 +142,7 @@ Restore a `FileBox.toJSON()` text string back to a FileBox instance.
 const restoredFileBox = FileBox.fromJSON(jsonText)
 ```
 
-#### 1.8 `FileBox.fromQRCode(qrCodeValue: string)`
+#### 1.9 `FileBox.fromQRCode(qrCodeValue: string, md5?: string)`
 
 Get a FileBox instance that represent a QR Code value.
 
@@ -139,9 +151,9 @@ const fileBox = FileBox.fromQRCode('https://github.com')
 fileBox.toFile('qrcode.png')
 ```
 
-#### 1.9 `FileBox.fromUuid(uuid: string)`
+#### 1.10 `FileBox.fromUuid(uuid: string, options?: {name?: string, size?: string, md5?: string})`
 
-Load a FileBox from a UUID.
+Load a FileBox from a UUID. Will be named `${uuid}.dat` if no name is provided.
 
 See: `FileBox.setUuidLoader()`
 
@@ -294,7 +306,19 @@ const fileBox = FileBox.fromRemote(
 console.log(fileBox.name) // Output: file-box-logo.jpg
 ```
 
-#### 3.2 `metadata: Metadata { [key: string]: any }`
+#### 3.2 `md5`
+
+File md5 of the file in the box. The value is set by user, not computed from file.
+
+```ts
+const fileBox = FileBox.fromUrl(
+  'https://huan.github.io/file-box/images/file-box-logo.jpg',
+  {md5: 'some-random-md5'}
+)
+console.log(fileBox.md5) // Output: some-random-md5
+```
+
+#### 3.3 `metadata: Metadata { [key: string]: any }`
 
 Metadata for the file in the box. This value can only be assigned once, and will be immutable afterwards, all following assign or modify actions on `metadata` will throw errors
 
@@ -311,26 +335,26 @@ console.log(fileBox.metadata)       // Output: { author: 'huan', githubRepo: 'ht
 fileBox.metadata.author = 'Tank'  // Will throw exception
 ```
 
-#### 3.3 `version(): string`
+#### 3.4 `version(): string`
 
 Version of the FileBox
 
-#### 3.4 `toJSON(): string`
+#### 3.5 `toJSON(): string`
 
 Serialize FileBox metadata to JSON.
 
-#### 3.5 `ready(): Promise<void>`
+#### 3.6 `ready(): Promise<void>`
 
 Update the necessary internal data and make everything ready for use.
 
-#### 3.6 `syncRemoteName(): Promise<void>`
+#### 3.7 `syncRemoteName(): Promise<void>`
 
 Sync the filename with the HTTP Response Header
 
 HTTP Header Example:
 > Content-Disposition: attachment; filename="filename.ext"
 
-#### 3.7 `type: FileBoxType`
+#### 3.8 `type: FileBoxType`
 
 Return the type of the current FileBox instance.
 
@@ -349,7 +373,7 @@ enum FileBoxType {
 }
 ```
 
-#### 3.8 `FileBox.setUuidLoader(loader: UuidLoader): void`
+#### 3.9 `FileBox.setUuidLoader(loader: UuidLoader): void`
 
 Required by static method `FileBox.fromUuid()`
 
@@ -373,7 +397,7 @@ The `UuidLoader` is a function that takes a UUID and return a readable stream.
 type UuidLoader = (this: FileBox, uuid: string) => Readable
 ```
 
-#### 3.9 `FileBox.setUuidSaver(saver: UuidSaver): void`
+#### 3.10 `FileBox.setUuidSaver(saver: UuidSaver): void`
 
 Required by instance method `fileBox.toUuid()`
 
@@ -397,7 +421,7 @@ The `UuidSaver` is a function that takes a readable stream and return a UUID pro
 type UuidSaver = (this: FileBox, stream: Readable) => Promise<string>
 ```
 
-#### 3.10 `size`
+#### 3.11 `size`
 
 The file box size in bytes. (`-1` means unknown)
 
@@ -411,7 +435,7 @@ console.log(fileBox.size)
 // > 20 <- this is the length of the URL string
 ```
 
-#### 3.11 `remoteSize`
+#### 3.12 `remoteSize`
 
 The remote file size in bytes. (`-1` or `undefined` means unknown)
 
@@ -473,6 +497,10 @@ console.log(fileBox.remoteSize)
 ```
 
 ## History
+
+### main v1.5 (Jan 18, 2022)
+
+1. `fileBox.md5` can be set by user. This filed is for the receiver of the filebox to check, and it is not computed from the file.
 
 ### main v1.4 (Nov 14, 2021)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-box",
-  "version": "1.4.14",
+  "version": "1.5.1",
   "description": "Pack a File into Box for easy move/transfer between servers no matter of where it is.(local path, remote url, or cloud storage)",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-box",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Pack a File into Box for easy move/transfer between servers no matter of where it is.(local path, remote url, or cloud storage)",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-box",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "description": "Pack a File into Box for easy move/transfer between servers no matter of where it is.(local path, remote url, or cloud storage)",
   "type": "module",
   "exports": {

--- a/src/file-box.ts
+++ b/src/file-box.ts
@@ -12,7 +12,6 @@ import * as PATH      from 'path'
 import * as URL       from 'url'
 
 import mime           from 'mime'
-import crypto from 'crypto'
 
 import {
   PassThrough,
@@ -175,13 +174,11 @@ class FileBox implements Pipeable, FileBoxInterface {
   static fromFile (
     path:   string,
     name?:  string,
+    md5?:    string,
   ): FileBox {
     if (!name) {
       name = PATH.parse(path).base
     }
-    const file = FS.readFileSync(path)
-    const hash = crypto.createHash('md5').update(file as any, 'utf8')
-    const md5 = hash.digest('hex')
     const options: FileBoxOptions = {
       md5,
       name,
@@ -198,8 +195,10 @@ class FileBox implements Pipeable, FileBoxInterface {
   static fromStream (
     stream: Readable,
     name?:  string,
+    md5?:   string,
   ): FileBox {
     const options: FileBoxOptions = {
+      md5,
       name: name || 'stream.dat',
       stream,
       type: FileBoxType.Stream,
@@ -210,9 +209,11 @@ class FileBox implements Pipeable, FileBoxInterface {
   static fromBuffer (
     buffer: Buffer,
     name?:   string,
+    md5?:    string,
   ): FileBox {
     const options: FileBoxOptions = {
       buffer,
+      md5,
       name: name || 'buffer.dat',
       type : FileBoxType.Buffer,
     }
@@ -226,9 +227,11 @@ class FileBox implements Pipeable, FileBoxInterface {
   static fromBase64 (
     base64: string,
     name?:   string,
+    md5?:    string,
   ): FileBox {
     const options: FileBoxOptions = {
       base64,
+      md5,
       name: name || 'base64.dat',
       type : FileBoxType.Base64,
     }
@@ -241,10 +244,12 @@ class FileBox implements Pipeable, FileBoxInterface {
   static fromDataURL (
     dataUrl : string,
     name?    : string,
+    md5?     : string,
   ): FileBox {
     return this.fromBase64(
       dataUrlToBase64(dataUrl),
       name || 'data-url.dat',
+      md5,
     )
   }
 
@@ -254,8 +259,10 @@ class FileBox implements Pipeable, FileBoxInterface {
    */
   static fromQRCode (
     qrCode: string,
+    md5?:   string,
   ): FileBox {
     const options: FileBoxOptions = {
+      md5,
       name: 'qrcode.png',
       qrCode,
       type: FileBoxType.QRCode,
@@ -281,6 +288,7 @@ class FileBox implements Pipeable, FileBoxInterface {
   static fromUuid (
     uuid: string,
     name?: string,
+    md5?: string,
   ): FileBox
 
   /**

--- a/src/file-box.ts
+++ b/src/file-box.ts
@@ -386,6 +386,7 @@ class FileBox implements Pipeable, FileBoxInterface {
         fileBox = FileBox.fromBase64(
           obj.base64,
           obj.name,
+          obj.md5,
         )
         break
 
@@ -393,12 +394,14 @@ class FileBox implements Pipeable, FileBoxInterface {
         fileBox = FileBox.fromUrl(obj.url, {
           name: obj.name,
           size: obj.size,
+          md5: obj.md5,
         })
         break
 
       case FileBoxType.QRCode:
         fileBox = FileBox.fromQRCode(
           obj.qrCode,
+          obj.md5,
         )
         break
 
@@ -406,6 +409,7 @@ class FileBox implements Pipeable, FileBoxInterface {
         fileBox = FileBox.fromUuid(obj.uuid, {
           name: obj.name,
           size: obj.size,
+          md5: obj.md5,
         })
         break
 

--- a/src/file-box.ts
+++ b/src/file-box.ts
@@ -392,9 +392,9 @@ class FileBox implements Pipeable, FileBoxInterface {
 
       case FileBoxType.Url:
         fileBox = FileBox.fromUrl(obj.url, {
+          md5: obj.md5,
           name: obj.name,
           size: obj.size,
-          md5: obj.md5,
         })
         break
 
@@ -407,9 +407,9 @@ class FileBox implements Pipeable, FileBoxInterface {
 
       case FileBoxType.Uuid:
         fileBox = FileBox.fromUuid(obj.uuid, {
+          md5: obj.md5,
           name: obj.name,
           size: obj.size,
-          md5: obj.md5,
         })
         break
 

--- a/src/file-box.ts
+++ b/src/file-box.ts
@@ -671,6 +671,7 @@ class FileBox implements Pipeable, FileBoxInterface {
 
   toJSON (): FileBoxJsonObject {
     const objCommon: FileBoxOptionsCommon = {
+      md5      : this.md5,
       metadata : this.metadata,
       name     : this.name,
     }

--- a/src/file-box.ts
+++ b/src/file-box.ts
@@ -121,7 +121,6 @@ class FileBox implements Pipeable, FileBoxInterface {
     url      : string,
     name?    : string,
     headers? : HTTP.OutgoingHttpHeaders,
-    md5?     : string,
   ): FileBox
 
   /**

--- a/src/file-box.type.ts
+++ b/src/file-box.type.ts
@@ -79,38 +79,31 @@ interface FileBoxOptionsCommon {
 interface FileBoxOptionsFile {
   type : FileBoxType.File
   path : string
-  md5? : string
 }
 interface FileBoxOptionsUrl {
   type     : FileBoxType.Url
   url      : string
   headers? : http.OutgoingHttpHeaders
-  md5?     : string
 }
 interface FileBoxOptionsBuffer {
   type   : FileBoxType.Buffer
   buffer : Buffer
-  md5?   : string
 }
 interface FileBoxOptionsStream {
   type   : FileBoxType.Stream
   stream : Readable
-  md5?   : string
 }
 interface FileBoxOptionsQRCode {
   type   : FileBoxType.QRCode,
   qrCode : string,
-  md5?   : string
 }
 interface FileBoxOptionsBase64 {
   type   : FileBoxType.Base64,
   base64 : string,
-  md5?   : string
 }
 interface FileBoxOptionsUuid {
   type : FileBoxType.Uuid
   uuid : string
-  md5? : string
 }
 
 type FileBoxOptions = FileBoxOptionsCommon & (

--- a/src/file-box.type.ts
+++ b/src/file-box.type.ts
@@ -78,31 +78,38 @@ interface FileBoxOptionsCommon {
 interface FileBoxOptionsFile {
   type : FileBoxType.File
   path : string
+  md5? : string
 }
 interface FileBoxOptionsUrl {
   type     : FileBoxType.Url
   url      : string
   headers? : http.OutgoingHttpHeaders
+  md5?     : string
 }
 interface FileBoxOptionsBuffer {
   type   : FileBoxType.Buffer
   buffer : Buffer
+  md5?   : string
 }
 interface FileBoxOptionsStream {
   type   : FileBoxType.Stream
   stream : Readable
+  md5?   : string
 }
 interface FileBoxOptionsQRCode {
   type   : FileBoxType.QRCode,
   qrCode : string,
+  md5?   : string
 }
 interface FileBoxOptionsBase64 {
   type   : FileBoxType.Base64,
   base64 : string,
+  md5?   : string
 }
 interface FileBoxOptionsUuid {
   type : FileBoxType.Uuid
-  uuid : string,
+  uuid : string
+  md5? : string
 }
 
 type FileBoxOptions = FileBoxOptionsCommon & (

--- a/src/file-box.type.ts
+++ b/src/file-box.type.ts
@@ -73,6 +73,7 @@ interface FileBoxOptionsCommon {
    * Size
    */
   size?: number
+  md5?: string
 }
 
 interface FileBoxOptionsFile {


### PR DESCRIPTION
For URL and UUid, allow user to pass md5 with options (because these two allow object as option)
For file, will compute and set md5

#74 